### PR TITLE
Make franchise optional

### DIFF
--- a/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/models/Game.kt
+++ b/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/models/Game.kt
@@ -19,7 +19,7 @@ data class Game(
   val name: String,
   val platforms: List<String>,
   val genres: List<String>,
-  val universes: List<String>?,
+  val universes: List<String>? = null,
   val companies: List<String>,
   val releaseDate: List<String>,
   val images: List<String>,

--- a/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/models/Game.kt
+++ b/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/models/Game.kt
@@ -19,7 +19,7 @@ data class Game(
   val name: String,
   val platforms: List<String>,
   val genres: List<String>,
-  val universes: List<String>,
+  val universes: List<String>?,
   val companies: List<String>,
   val releaseDate: List<String>,
   val images: List<String>,

--- a/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/models/GameInstance.kt
+++ b/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/models/GameInstance.kt
@@ -22,7 +22,7 @@ data class GameInstance(
   val name: String,
   val platforms: List<String>,
   val genres: List<String>,
-  val universes: List<String>?,
+  val universes: List<String>? = null,
   val companies: List<String>,
   val releaseDate: List<String>,
   val images: List<String>,

--- a/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/models/GameInstance.kt
+++ b/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/models/GameInstance.kt
@@ -22,7 +22,7 @@ data class GameInstance(
   val name: String,
   val platforms: List<String>,
   val genres: List<String>,
-  val universes: List<String>,
+  val universes: List<String>?,
   val companies: List<String>,
   val releaseDate: List<String>,
   val images: List<String>,

--- a/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/models/igdb/IGDBGame.kt
+++ b/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/models/igdb/IGDBGame.kt
@@ -11,12 +11,11 @@ import lombok.NoArgsConstructor
 data class IGDBGame(
   val id: Long,
   val artworks: List<ArtworkInfo>,
-  val franchises: List<FieldInfo>,
+  val franchises: List<FieldInfo>?,
   val genres: List<FieldInfo>,
   val involved_companies: List<CompanyFieldInfo>,
   val name: String,
   val platforms: List<FieldInfo>,
   val release_dates: List<ReleaseDate>,
   val summary: String
-) {
-}
+)

--- a/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/services/GameService.kt
+++ b/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/services/GameService.kt
@@ -61,7 +61,7 @@ class GameService(
       platforms = extractFieldInfo(igdbGame.platforms),
       genres = extractFieldInfo(igdbGame.genres),
       companies = extractCompanyFieldInfo(igdbGame.involved_companies),
-      universes = extractFieldInfo(igdbGame.franchises),
+      universes = if (igdbGame.franchises.isNullOrEmpty()) null else extractFieldInfo(igdbGame.franchises),
       images = extractArtworkFieldInfo(igdbGame.artworks),
       releaseDate = extractReleaseDateFieldInfo(igdbGame.release_dates),
       summary = igdbGame.summary,

--- a/src/test/kotlin/com/gamingbacklog/api/gamingbacklogapi/unit/clients/IGDBClientTests.kt
+++ b/src/test/kotlin/com/gamingbacklog/api/gamingbacklogapi/unit/clients/IGDBClientTests.kt
@@ -73,7 +73,7 @@ class IGDBClientTests {
       val result = igdbClient.gamesRequest("test_secret", "191")
       Assertions.assertEquals(result[0].id, 191411)
       Assertions.assertEquals(result[0].artworks[0].url, "//images.igdb.com/igdb/image/upload/t_thumb/ar1lkx.jpg")
-      Assertions.assertEquals(result[0].franchises[0].name, "Xenoblade")
+      Assertions.assertEquals(result[0].franchises?.get(0)?.name, "Xenoblade")
       Assertions.assertEquals(result[0].genres[0].name, "Role-playing (RPG)")
       Assertions.assertEquals(result[0].genres[1].name, "Adventure")
       Assertions.assertEquals(result[0].involved_companies[0].company.name, "Monolith Soft")
@@ -82,6 +82,27 @@ class IGDBClientTests {
       Assertions.assertEquals(result[0].release_dates[0].human, "Jul 29, 2022")
       Assertions.assertEquals(result[0].summary, "Eunie's the bussss")
     }
+
+    @Test
+    fun shouldSuccessfullyReturnGameWithEmptyFranchise() {
+      given(externalAPIClient.postExternalCall(any(), any(), any())).willReturn(
+        MockResponse(
+          ResponseConstants.mockIGDBGetGame200ResponseNoFranchise,
+          200
+        )
+      )
+      val result = igdbClient.gamesRequest("test_secret", "191")
+      Assertions.assertEquals(result[0].id, 191407)
+      Assertions.assertEquals(result[0].artworks[0].url, "//images.igdb.com/igdb/image/upload/t_thumb/ar1gck.jpg")
+      Assertions.assertNull(result[0].franchises)
+      Assertions.assertEquals(result[0].genres[0].name, "Role-playing (RPG)")
+      Assertions.assertEquals(result[0].genres[1].name, "Adventure")
+      Assertions.assertEquals(result[0].involved_companies[0].company.name, "Square Enix")
+      Assertions.assertEquals(result[0].name, "Live A Live")
+      Assertions.assertEquals(result[0].release_dates[0].human, "Jul 22, 2022")
+      Assertions.assertEquals(result[0].summary, "is it live or live")
+    }
+
     @Test
     fun shouldReturn400SyntaxError() {
       given(externalAPIClient.postExternalCall(any(), any(), any())).willReturn(

--- a/src/test/kotlin/com/gamingbacklog/api/gamingbacklogapi/unit/controllers/GameInstanceControllerTests.kt
+++ b/src/test/kotlin/com/gamingbacklog/api/gamingbacklogapi/unit/controllers/GameInstanceControllerTests.kt
@@ -122,10 +122,16 @@ class GameInstanceControllerTests {
   inner class CreateGameInstance {
     @Test
     fun shouldSuccessfullyCreateGame() {
-      val newGame = GameInstance(id1, "igdb1", "Celeste",
-        arrayListOf("Nintendo Switch", "PC", "PS4", "Xbox One"),
-        arrayListOf("Platformer"), arrayListOf("Celeste"), arrayListOf("Extremely OK Games"),
-        arrayListOf("2018"), arrayListOf("so mountain"), "Climb up the mountain in this hard platformer")
+      val newGame = GameInstance(
+        id = id1,
+        igdbId = "igdb1",
+        name = "Celeste",
+        platforms = arrayListOf("Nintendo Switch", "PC", "PS4", "Xbox One"),
+        genres = arrayListOf("Platformer"),
+        companies = arrayListOf("Extremely OK Games"),
+        releaseDate = arrayListOf("2018"),
+        images = arrayListOf("so mountain"),
+        summary = "Climb up the mountain in this hard platformer")
       given(gameInstanceService.create(any())).willReturn(newGame)
       val gameInstanceRequest = GameInstanceRequest("igdb1",
         null, null, null, null, null, null, null)
@@ -139,7 +145,7 @@ class GameInstanceControllerTests {
         .andExpect(jsonPath("$.platforms[2]", equalTo(newGame.platforms[2])))
         .andExpect(jsonPath("$.platforms[3]", equalTo(newGame.platforms[3])))
         .andExpect(jsonPath("$.genres[0]", equalTo(newGame.genres[0])))
-        .andExpect(jsonPath("$.universes[0]", equalTo(newGame.universes[0])))
+        .andExpect(jsonPath("$.universes", equalTo(null)))
         .andExpect(jsonPath("$.companies[0]", equalTo(newGame.companies[0])))
         .andExpect(jsonPath("$.releaseDate[0]", equalTo(newGame.releaseDate[0])))
         .andExpect(jsonPath("$.images[0]", equalTo(newGame.images[0])))

--- a/src/test/kotlin/com/gamingbacklog/api/gamingbacklogapi/unit/testutil/constants/ResponseConstants.kt
+++ b/src/test/kotlin/com/gamingbacklog/api/gamingbacklogapi/unit/testutil/constants/ResponseConstants.kt
@@ -60,6 +60,50 @@ object ResponseConstants {
     "    \"summary\": \"Eunie's the bussss\"\n" +
     "  }\n" +
     "]"
+  const val mockIGDBGetGame200ResponseNoFranchise = "[\n" +
+    "  {\n" +
+    "    \"id\": 191407,\n" +
+    "    \"artworks\": [\n" +
+    "      {\n" +
+    "        \"id\": 67844,\n" +
+    "        \"url\": \"//images.igdb.com/igdb/image/upload/t_thumb/ar1gck.jpg\"\n" +
+    "      }\n" +
+    "    ],\n" +
+    "    \"genres\": [\n" +
+    "      {\n" +
+    "        \"id\": 12,\n" +
+    "        \"name\": \"Role-playing (RPG)\"\n" +
+    "      },\n" +
+    "      {\n" +
+    "        \"id\": 31,\n" +
+    "        \"name\": \"Adventure\"\n" +
+    "      }\n" +
+    "    ],\n" +
+    "    \"involved_companies\": [\n" +
+    "      {\n" +
+    "        \"id\": 163651,\n" +
+    "        \"company\": {\n" +
+    "          \"id\": 26,\n" +
+    "          \"name\": \"Square Enix\"\n" +
+    "        }\n" +
+    "      }\n" +
+    "    ],\n" +
+    "    \"name\": \"Live A Live\",\n" +
+    "    \"platforms\": [\n" +
+    "      {\n" +
+    "        \"id\": 130,\n" +
+    "        \"name\": \"Nintendo Switch\"\n" +
+    "      }\n" +
+    "    ],\n" +
+    "    \"release_dates\": [\n" +
+    "      {\n" +
+    "        \"id\": 354757,\n" +
+    "        \"human\": \"Jul 22, 2022\"\n" +
+    "      }\n" +
+    "    ],\n" +
+    "    \"summary\": \"is it live or live\"\n" +
+    "  }\n" +
+    "]"
   const val mockIGDBGetGame400Response = "Status Code: 400, Error: [\n" +
     "  {\n" +
     "    \"title\": \"Syntax Error\",\n" +


### PR DESCRIPTION
## Jira Ticket Number
https://gaming-backlog.atlassian.net/browse/GB-72

## Short description
Makes it so franchise can be nullable. This allows it to not be displayed on the frontend, and to not force franchise to be a required field for certain games that are on their own (e.g. indie games). Examples currently in our DB include Chicory and Live a Live.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Other (please specify)