### PR TITLE
Return Library in AddToLibrary/RemoveFromLibrary and Refactoring

### DIFF
--- a/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/controllers/LibraryController.kt
+++ b/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/controllers/LibraryController.kt
@@ -3,6 +3,7 @@ package com.gamingbacklog.api.gamingbacklogapi.controllers
 import com.gamingbacklog.api.gamingbacklogapi.models.GameInstance
 import com.gamingbacklog.api.gamingbacklogapi.models.Library
 import com.gamingbacklog.api.gamingbacklogapi.models.requests.LibraryRequest
+import com.gamingbacklog.api.gamingbacklogapi.models.requests.UpdateLibraryGamesRequest
 import com.gamingbacklog.api.gamingbacklogapi.models.responses.LibraryResponse
 import com.gamingbacklog.api.gamingbacklogapi.services.LibraryService
 import org.springframework.http.HttpStatus
@@ -59,14 +60,14 @@ class LibraryController(private val libraryService: LibraryService) {
   }
 
   @CrossOrigin(origins = ["http://localhost:3000", "http://localhost:3000/libraries"])
-  @PutMapping("/{libraryId}/addToLibrary")
+  @PostMapping("/{libraryId}/games")
   fun addToLibrary(
     @PathVariable("libraryId") libraryId: String,
-    @RequestBody addGameToLibrary: Map<String, String>
-  ): ResponseEntity<String> {
-    val gameId = addGameToLibrary["gameId"] ?: throw Exception("gameId must be provided")
-    libraryService.addToLibrary(libraryId, gameId)
-    return ResponseEntity.ok("Successfully added game to library")
+    @RequestBody addGameToLibrary: UpdateLibraryGamesRequest
+  ): ResponseEntity<LibraryResponse> {
+    val library = libraryService.addToLibrary(libraryId, addGameToLibrary.gameId)
+      ?: return ResponseEntity<LibraryResponse>(HttpStatus.NOT_FOUND)
+    return ResponseEntity.ok(libraryService.convertLibraryToResponse(library))
   }
 
   @GetMapping("/{id}/games/{gameId}")
@@ -79,13 +80,14 @@ class LibraryController(private val libraryService: LibraryService) {
     return ResponseEntity<GameInstance>(game, HttpStatus.OK)
   }
 
-  @DeleteMapping("/{id}/games/{gameId}")
+  @DeleteMapping("/{id}/games")
   fun deleteGameFromLibrary(
     @PathVariable("id") libraryId: String,
-    @PathVariable("gameId") gameId: String
-  ): ResponseEntity<String> {
-    libraryService.deleteGameFromLibrary(libraryId, gameId)
-    return ResponseEntity.ok("Successfully deleted game $gameId from library $libraryId")
+    @RequestBody removeGameFromLibrary: UpdateLibraryGamesRequest
+  ): ResponseEntity<LibraryResponse> {
+    val library = libraryService.deleteGameFromLibrary(libraryId, removeGameFromLibrary.gameId)
+      ?: return ResponseEntity<LibraryResponse>(HttpStatus.NOT_FOUND)
+    return ResponseEntity.ok(libraryService.convertLibraryToResponse(library))
   }
 
   @DeleteMapping("/{id}")

--- a/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/models/requests/UpdateLibraryGamesRequest.kt
+++ b/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/models/requests/UpdateLibraryGamesRequest.kt
@@ -1,0 +1,6 @@
+package com.gamingbacklog.api.gamingbacklogapi.models.requests
+
+class UpdateLibraryGamesRequest(
+  var gameId: String
+) : Request() {
+}

--- a/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/services/LibraryService.kt
+++ b/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/services/LibraryService.kt
@@ -51,20 +51,22 @@ class LibraryService (
     libraryRepository.save(model)
   }
 
-  fun addToLibrary(libraryId: String, gameId: String) {
+  fun addToLibrary(libraryId: String, gameId: String): Library? {
     val library = getSingle(libraryId)
     if (library != null) {
       library.games.add(gameId)
       update(library)
     }
+    return library
   }
 
-  fun deleteGameFromLibrary(libraryId: String, gameId: String) {
+  fun deleteGameFromLibrary(libraryId: String, gameId: String): Library? {
     val library = getSingle(libraryId)
     if (library != null) {
       library.games.remove(gameId)
       update(library)
     }
+    return library
   }
 
   // TODO: error handling here

--- a/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/services/LibraryService.kt
+++ b/src/main/kotlin/com/gamingbacklog/api/gamingbacklogapi/services/LibraryService.kt
@@ -84,12 +84,12 @@ class LibraryService (
   }
 
   fun convertLibraryToResponse(library: Library): LibraryResponse {
-    if (library.games.size > 0) {
+    return if (library.games.size > 0) {
       val games: List<GameInstance> = library.games.map { gameId -> getGameFromLibrary(library.id, gameId)!! }
       val gameResponses = games.map { game -> GameResponse(game.id, game.name) }
-      return LibraryResponse(id = library.id, name = library.name, games = gameResponses)
+      LibraryResponse(id = library.id, name = library.name, games = gameResponses)
     } else {
-      return LibraryResponse(id = library.id, name = library.name, games = emptyList());
+      LibraryResponse(id = library.id, name = library.name, games = emptyList());
     }
   }
 

--- a/src/test/kotlin/com/gamingbacklog/api/gamingbacklogapi/unit/controllers/LibraryControllerTests.kt
+++ b/src/test/kotlin/com/gamingbacklog/api/gamingbacklogapi/unit/controllers/LibraryControllerTests.kt
@@ -206,6 +206,8 @@ class LibraryControllerTests {
       val request = UpdateLibraryGamesRequest(id1)
       requestBuilder.runDeleteRequest("$endpoint$id2/games", Gson().toJson(request))
         .andExpect(status().isOk)
+      Assertions.assertFalse(library.games.contains("id1"))
+      Assertions.assertTrue(library.games.containsAll(listOf("id2", "id3")))
     }
   }
 

--- a/src/test/kotlin/com/gamingbacklog/api/gamingbacklogapi/unit/controllers/LibraryControllerTests.kt
+++ b/src/test/kotlin/com/gamingbacklog/api/gamingbacklogapi/unit/controllers/LibraryControllerTests.kt
@@ -4,6 +4,7 @@ import com.gamingbacklog.api.gamingbacklogapi.controllers.LibraryController
 import com.gamingbacklog.api.gamingbacklogapi.models.GameInstance
 import com.gamingbacklog.api.gamingbacklogapi.models.Library
 import com.gamingbacklog.api.gamingbacklogapi.models.requests.LibraryRequest
+import com.gamingbacklog.api.gamingbacklogapi.models.requests.UpdateLibraryGamesRequest
 import com.gamingbacklog.api.gamingbacklogapi.services.LibraryService
 import com.google.gson.Gson
 import org.hamcrest.CoreMatchers.*
@@ -128,10 +129,10 @@ class LibraryControllerTests {
       val library = Library(id2, "Backlog", ArrayList())
       given(libraryService.addToLibrary(any(), any())).will {
         library.games.add(id1)
+        library
       }
-      val map = HashMap<String, String>()
-      map["gameId"] = id1
-      requestBuilder.runPutRequest("$endpoint/$id2/addToLibrary", Gson().toJson(map))
+      val request = UpdateLibraryGamesRequest(id1)
+      requestBuilder.runPostRequest("$endpoint$id2/games", Gson().toJson(request))
         .andExpect(status().isOk)
       Assertions.assertTrue(library.games.contains(id1))
     }
@@ -198,13 +199,13 @@ class LibraryControllerTests {
     @Test
     fun shouldSuccessfullyDeleteGameFromLibrary() {
       val library = Library("library-id1", "Backlog", arrayListOf("id1", "id2", "id3"))
-      given(libraryService.deleteGameFromLibrary("library-id1", "id1")).will {
+      given(libraryService.deleteGameFromLibrary(id2, id1)).will {
         library.games.remove("id1")
+        library
       }
-      endpoint += "library-id1/games/id1"
-      requestBuilder.runDeleteRequest(endpoint)
+      val request = UpdateLibraryGamesRequest(id1)
+      requestBuilder.runDeleteRequest("$endpoint$id2/games", Gson().toJson(request))
         .andExpect(status().isOk)
-        .andExpect(content().string(containsString("Successfully deleted game id1 from library library-id")))
     }
   }
 

--- a/src/test/kotlin/com/gamingbacklog/api/gamingbacklogapi/unit/controllers/RequestBuilder.kt
+++ b/src/test/kotlin/com/gamingbacklog/api/gamingbacklogapi/unit/controllers/RequestBuilder.kt
@@ -32,8 +32,13 @@ class RequestBuilder(private val mockMvc: MockMvc) {
     )
   }
 
-  fun runDeleteRequest(url: String): ResultActions {
-    return mockMvc.perform(delete(url))
+  fun runDeleteRequest(url: String, request: String? = null): ResultActions {
+    if (request == null)
+      return mockMvc.perform(delete(url))
+    return mockMvc.perform(delete(url)
+      .contentType(MediaType.APPLICATION_JSON)
+      .content(request)
+    )
   }
 
 


### PR DESCRIPTION
## Jira Ticket Number
https://gaming-backlog.atlassian.net/browse/GB-78

## Short description
We are now returning the library when updating it. Additionally, AddtoLibrary is now a POST request and the endpoint is now /games rather than `addToLibrary` (removeFromLibrary is the same but with DELETE)

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [x] Other (please specify): Refactor